### PR TITLE
Order claude-code/pi-dev after stable Features for cache efficiency

### DIFF
--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -17,6 +17,20 @@
             "description": "Release channel or exact version to install: 'stable', 'latest', or a semver like '1.2.3'."
         },
     },
-    // No installsAfter: confirmed the installer is a self-contained native
-    // binary download with no npm/node dependency (see install.sh).
+    // No functional dependency (confirmed the installer is a self-contained
+    // native binary download with no npm/node dependency - see install.sh),
+    // but installsAfter is still used here purely for build-cache ordering:
+    // this Feature tracks the 'latest' release channel and updates far more
+    // often than the Features below, and Docker's cache key chains
+    // sequentially - putting a frequently-changing Feature early would
+    // cascade-invalidate every Feature after it on most builds. Installing
+    // last keeps the stable prefix cache-hit even when this one changes.
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/copilot-cli",
+        "ghcr.io/devcontainers/features/github-cli",
+        "ghcr.io/devcontainers/features/node",
+        "ghcr.io/devcontainers/features/python",
+        "ghcr.io/devcontainers/features/sshd",
+    ],
 }

--- a/src/pi-dev/devcontainer-feature.json
+++ b/src/pi-dev/devcontainer-feature.json
@@ -6,7 +6,18 @@
     "description": "Installs the Pi coding agent CLI via the official pi.dev installer. Requires Node.js >=22.19.0 and npm.",
     "documentationURL": "https://pi.dev",
     "keywords": ["pi", "pi.dev", "ai"],
+    // node is a hard dependency (this Feature needs npm). The rest are ordering-
+    // only hints: this Feature installs from npm at build time and tends to
+    // change often, and Docker's cache key chains sequentially - putting a
+    // frequently-changing Feature early would cascade-invalidate every
+    // Feature after it on most builds. Installing last keeps the stable
+    // prefix cache-hit even when this one changes.
     "installsAfter": [
         "ghcr.io/devcontainers/features/node",
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/copilot-cli",
+        "ghcr.io/devcontainers/features/github-cli",
+        "ghcr.io/devcontainers/features/python",
+        "ghcr.io/devcontainers/features/sshd",
     ],
 }


### PR DESCRIPTION
Companion to bugrasan/devcontainer-base-ai's build-speed work.

Neither reordering `devcontainer.json`'s feature declaration nor a Feature's own position in the JSON affects actual install order — the devcontainer CLI computes its own topological sort of `installsAfter` constraints (confirmed against real build logs: `claude-code` was installing essentially first among Features in `:base`'s image despite being declared near the end of the list).

Docker/BuildKit layer cache keys chain sequentially (parent key + this instruction), so a cache-miss on one Feature invalidates every Feature after it, regardless of their own content. `claude-code` (tracks the `latest` release channel) and `pi-dev` (installs from npm at build time) both change far more often than `common-utils`/`copilot-cli`/`github-cli`/`node`/`python`/`sshd` — this adds `installsAfter` on those stable Features (purely for cache-ordering; `node` remains the only functional dependency, for `pi-dev`) so the volatile ones install last, keeping the stable prefix cache-hit even when claude/pi ship new releases.

No functional/behavioral change — pure ordering hint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNcto2mV1zgsHHfeA2K8sQ)_