### PR TITLE
Bump claude-code/pi-dev to 1.0.1 (PR #15's ordering fix never published)

### DIFF
--- a/src/claude-code/devcontainer-feature.json
+++ b/src/claude-code/devcontainer-feature.json
@@ -2,7 +2,7 @@
     // https://containers.dev/implementors/features/
     "name": "claude-code",
     "id": "claude-code",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs the Claude Code CLI (Anthropic's agentic coding tool) via its native installer.",
     "documentationURL": "https://code.claude.com/docs/en/overview",
     "keywords": ["claude", "claude-code", "anthropic", "ai"],

--- a/src/pi-dev/devcontainer-feature.json
+++ b/src/pi-dev/devcontainer-feature.json
@@ -2,7 +2,7 @@
     // https://containers.dev/implementors/features/
     "name": "pi-dev",
     "id": "pi-dev",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Installs the Pi coding agent CLI via the official pi.dev installer. Requires Node.js >=22.19.0 and npm.",
     "documentationURL": "https://pi.dev",
     "keywords": ["pi", "pi.dev", "ai"],


### PR DESCRIPTION
The publish step only republishes a Feature (and moves its floating `1`/`1.0`/`latest` tags) when its `version` field actually changes - confirmed from the PR #15 release run's own log output: `{"claude-code":{},"pi-dev":{}}` (empty result = skipped), and the same log shows an explicit `"(!) WARNING: Version X already exists, skipping"` for the two other Features in this repo hitting the same unchanged-version path.

PR #15 changed `installsAfter` but left `version` at `1.0.0`, so that change silently never reached ghcr - confirmed against a real `devcontainer-base-ai` validation build run *after* PR #15 merged: `claude-code` was still installing first among Features, completely unchanged from before the fix.

No content changes beyond the version bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNcto2mV1zgsHHfeA2K8sQ)_